### PR TITLE
Run rackup with --quiet

### DIFF
--- a/local-dev/aws-lambda-ruby-postgres/2.7/Dockerfile
+++ b/local-dev/aws-lambda-ruby-postgres/2.7/Dockerfile
@@ -17,4 +17,4 @@ ENV GEM_PATH /bundle
 ENV BUNDLE_PATH /bundle
 
 # Start server using rerun to reload if code changes are detected
-CMD ["rerun", "--background", "bundle", "exec", "rackup --host 0.0.0.0"]
+CMD ["rerun", "--background", "bundle", "exec", "rackup --host 0.0.0.0 --quiet"]


### PR DESCRIPTION
This disables the default logging for rack, but sinatra will still write logs, and we can customise those logs as desired.