### PR TITLE
Get Ruby 3.3 images built using development SYS lambda layer for postgres stuff

### DIFF
--- a/.github/workflows/aws-lambda-ruby.yml
+++ b/.github/workflows/aws-lambda-ruby.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [aws-lambda-ruby-dev, aws-lambda-ruby-postgres]
-        ruby: [2.7, 3.2]
+        ruby: [2.7, 3.2, 3.3]
     name: Build ci/${{ matrix.image }}:${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [aws-lambda-ruby-dev, aws-lambda-ruby-postgres]
-        ruby: [2.7, 3.2]
+        ruby: [2.7, 3.2, 3.3]
     name: Build local-dev/${{ matrix.image }}:${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4

--- a/ci/aws-lambda-ruby-dev/3.3/Dockerfile
+++ b/ci/aws-lambda-ruby-dev/3.3/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:latest
+FROM public.ecr.aws/lambda/ruby:3.3
+
+# Don't complain if bundler is run as root
+ENV BUNDLE_SILENCE_ROOT_WARNING=1
+
+RUN yum install -y amazon-linux-extras yum-utils \
+  && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
+  && amazon-linux-extras enable postgresql14 \
+  && yum install -y \
+  postgresql \
+  postgresql-devel \
+  sqlite-devel \
+  openssl-devel \
+  wget \
+  make \
+  gcc \
+  gcc-c++ \
+  git \
+  gh \
+  && yum clean all \
+  && rm -rf /var/cache/yum
+
+RUN gem install bundler
+
+# Override default lambda entrypoint
+ENTRYPOINT []
+
+# Set default command to match the ruby docker images
+CMD ["irb"]

--- a/ci/aws-lambda-ruby-dev/3.3/Dockerfile
+++ b/ci/aws-lambda-ruby-dev/3.3/Dockerfile
@@ -1,4 +1,3 @@
-FROM ubuntu:latest
 FROM public.ecr.aws/lambda/ruby:3.3
 
 # Don't complain if bundler is run as root

--- a/ci/aws-lambda-ruby-postgres/3.3/Dockerfile
+++ b/ci/aws-lambda-ruby-postgres/3.3/Dockerfile
@@ -1,0 +1,10 @@
+FROM public.ecr.aws/lambda/ruby:3.3
+
+# Add lambda layer with postgres libraries
+ADD sys-layer-ruby-pg.tgz /opt
+
+# Override default lambda entrypoint
+ENTRYPOINT []
+
+# Set default command to match the ruby docker images
+CMD ["irb"]

--- a/ci/aws-lambda-ruby-postgres/3.3/get-dependencies.sh
+++ b/ci/aws-lambda-ruby-postgres/3.3/get-dependencies.sh
@@ -2,7 +2,7 @@
 
 # Gets a zip file for the given lambda layer ARN
 
-# Dev SYS AWS account - use production ARN when available
+# TODO: Dev SYS AWS account - use production ARN when available
 LAYER_ARN=arn:aws:lambda:eu-west-1:777293634910:layer:sys-layer-ruby-pg:1
 URL=$(aws lambda get-layer-version-by-arn --arn $LAYER_ARN --query Content.Location --output text)
 curl -s $URL -o sys-layer-ruby-pg.zip

--- a/ci/aws-lambda-ruby-postgres/3.3/get-dependencies.sh
+++ b/ci/aws-lambda-ruby-postgres/3.3/get-dependencies.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Gets a zip file for the given lambda layer ARN
+
+# Dev SYS AWS account - use production ARN when available
+LAYER_ARN=arn:aws:lambda:eu-west-1:777293634910:layer:sys-layer-ruby-pg:1
+URL=$(aws lambda get-layer-version-by-arn --arn $LAYER_ARN --query Content.Location --output text)
+curl -s $URL -o sys-layer-ruby-pg.zip
+
+# Convert the zip to tgz so docker can ADD the archive automatically
+
+unzip -q sys-layer-ruby-pg.zip -d layer
+tar -C layer -zcf sys-layer-ruby-pg.tgz .
+rm -rf layer sys-layer-ruby-pg.zip

--- a/ci/aws-lambda-ruby-postgres/3.3/get-dependencies.sh
+++ b/ci/aws-lambda-ruby-postgres/3.3/get-dependencies.sh
@@ -2,7 +2,7 @@
 
 # Gets a zip file for the given lambda layer ARN
 
-# TODO: Dev SYS AWS account - use production ARN when available
+# TODO: FD-2030 - Dev SYS AWS account - use production ARN when available
 LAYER_ARN=arn:aws:lambda:eu-west-1:777293634910:layer:sys-layer-ruby-pg:1
 URL=$(aws lambda get-layer-version-by-arn --arn $LAYER_ARN --query Content.Location --output text)
 curl -s $URL -o sys-layer-ruby-pg.zip

--- a/local-dev/aws-lambda-ruby-dev/3.3/Dockerfile
+++ b/local-dev/aws-lambda-ruby-dev/3.3/Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-dev:3.3
+
+# Use /bundle for gems
+ENV GEM_PATH /bundle
+ENV BUNDLE_PATH /bundle
+ENV BUNDLE_CLEAN true

--- a/local-dev/aws-lambda-ruby-postgres/3.3/Dockerfile
+++ b/local-dev/aws-lambda-ruby-postgres/3.3/Dockerfile
@@ -1,0 +1,21 @@
+FROM ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-dev:3.3 as app-build
+
+# We must install rerun in a dev image that has build tools installed
+RUN gem install rerun:'~> 0.13'
+
+###############################################################################
+FROM ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-postgres:3.3
+
+# Pick up rerun gem from build stage
+COPY --from=app-build /var/lang /var/lang
+
+# Open port for local development
+EXPOSE 9292
+
+# Use /bundle for gems
+ENV GEM_PATH /bundle
+ENV BUNDLE_PATH /bundle
+ENV BUNDLE_CLEAN true
+
+# Start server using rerun to reload if code changes are detected
+CMD ["rerun", "--background", "bundle", "exec", "rackup --host 0.0.0.0 --quiet"]


### PR DESCRIPTION
# Context
AWS have release a Ruby Lambda image with support for Ruby v3.3, based on a more recent Linux image. Ideally, we want to move over to using this lambda image!

In order to do this, we need to make sure our various docker images used for both CI and local development are based off of this new lambda image.

These images are added to the GitHub Container Registry (GHCR) via an automated GitHub Actions workflow.

# Aim
Create new Dockerfiles, scripts etc. to get new images built based off of this new Ruby 3.3 AWS Lambda image, along with the pre-existing images based off of v2.7 and v3.2.

# Implementation
SYS have provided the ARN for their Lambda-layer we make use of for our `aws-lambda-ruby-postgres` images (both `local-dev` and `CI`) - see the `get-dependencies.sh` scripts. **Note that this is in their development AWS account**, with the intention of us testing it out before deployment into their production AWS account.

Otherwise, the changes are basically:
- Adding new `Dockerfiles` for the 3.3 images
- Adding an extra value to the `ruby` version matrix in the workflow file

