### PR TITLE
Get "dnf" commands working instead of yum

### DIFF
--- a/ci/aws-lambda-ruby-dev/3.3/Dockerfile
+++ b/ci/aws-lambda-ruby-dev/3.3/Dockerfile
@@ -3,11 +3,10 @@ FROM public.ecr.aws/lambda/ruby:3.3
 # Don't complain if bundler is run as root
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 
-RUN yum install -y amazon-linux-extras yum-utils \
-  && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
-  && amazon-linux-extras enable postgresql14 \
-  && yum install -y \
-  postgresql \
+RUN dnf install -y 'dnf-command(config-manager)' \
+  && dnf-3 config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
+  && dnf install -y \
+  postgresql15 \
   postgresql-devel \
   sqlite-devel \
   openssl-devel \
@@ -17,7 +16,7 @@ RUN yum install -y amazon-linux-extras yum-utils \
   gcc-c++ \
   git \
   gh \
-  && yum clean all \
+  && dnf clean all \
   && rm -rf /var/cache/yum
 
 RUN gem install bundler


### PR DESCRIPTION
# Context

Unfortunately, the AWS Lambda base images (including the Ruby 3.3 one) doesn't have `yum` - it uses `dnf` (specifically `microdnf`) instead.

# Implementation
For the `ci-lambda-ruby-dev` image, get the equivalent `dnf` commands working along with the relevant packages. 

Unfortunately there's no `postgresql` meta-package, so `postgresql15` needs to be specified instead.

Also, `config-manager` doesn't exist yet for the latest version of `dnf` (I think v5), so we have to use `dnf-3` to get `config-manager` to add a repository.

Additionally, there's no `amazon-linux-extras` equivalent for Amazon Linux 2023-derived images (such as the Lambda images), so we can't get that installed either.

# Testing
I've managed to get both the `ci-lambda-ruby-dev` and `ci-lambda-ruby-postgres` images successfully built, however it's a bit tricky to test with `docker-compose` as it doesn't seem to like using local-only images.
