### PR TITLE
FD-2177: libffi manual install

### DIFF
--- a/ci/aws-lambda-ruby-dev/3.2/Dockerfile
+++ b/ci/aws-lambda-ruby-dev/3.2/Dockerfile
@@ -18,7 +18,6 @@ RUN yum install -y amazon-linux-extras yum-utils \
   git \
   gh \
   tar \
-  libffi-devel \
   && yum clean all \
   && rm -rf /var/cache/yum
 

--- a/ci/aws-lambda-ruby-dev/3.2/Dockerfile
+++ b/ci/aws-lambda-ruby-dev/3.2/Dockerfile
@@ -18,6 +18,7 @@ RUN yum install -y amazon-linux-extras yum-utils \
   git \
   gh \
   tar \
+  libffi-devel \
   && yum clean all \
   && rm -rf /var/cache/yum
 

--- a/local-dev/aws-lambda-ruby-postgres/3.2/Dockerfile
+++ b/local-dev/aws-lambda-ruby-postgres/3.2/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-dev:3.2 as app-build
 
 # We must install rerun in a dev image that has build tools installed
+RUN gem install ffi -- --enable-system-libffi
 RUN gem install rerun:'~> 0.13'
 
 ###############################################################################

--- a/local-dev/aws-lambda-ruby-postgres/3.2/Dockerfile
+++ b/local-dev/aws-lambda-ruby-postgres/3.2/Dockerfile
@@ -1,8 +1,8 @@
 FROM ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-dev:3.2 as app-build
 
 # We must install rerun in a dev image that has build tools installed
-RUN gem install ffi -- --enable-system-libffi
-RUN gem install rerun:'~> 0.13'
+# Build from source to avoid compatability issues with binary packages
+RUN gem install rerun:'~> 0.13' --platform ruby
 
 ###############################################################################
 FROM ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-postgres:3.2


### PR DESCRIPTION
# Context
Our local dev `app` images aren't working! This is because the binary package for the "ffi" gem (a dependency of the `rerun` gem we install on the local-dev postgres ruby image) looks to have recently started being built on a newer platform. This meant that one of the libraries it came bundled with (`ffi_c.so`) was linked against a newer version of GLIBC than what we had on our AL2 runtime images, and complained when it couldn't find a compatible version.

# Implementation
Essentially, this change makes it so that:
a) the `libffi-devel` package is available on the image where the `rerun` gem is installed on
b) the `rerun` gem, and all of its dependencies, are built from source instead of using the pre-built binaries and libraries

The end result is that the `ffi` gem should make use of the system's own ffi libraries, and so shouldn't encounter any compatibility issues at runtime.