### PR TITLE
FD-2181: Add xz as a system dependency

### DIFF
--- a/ci/aws-lambda-ruby-dev/3.2/Dockerfile
+++ b/ci/aws-lambda-ruby-dev/3.2/Dockerfile
@@ -18,6 +18,7 @@ RUN yum install -y amazon-linux-extras yum-utils \
   git \
   gh \
   tar \
+  xz \
   && yum clean all \
   && rm -rf /var/cache/yum
 


### PR DESCRIPTION
For `nokogiri` gem native build, which requires the xzcat exec; the `xz` package provides this.