### PR TITLE
Ensure additional mirror list is added for openssl-snapsafe

### DIFF
--- a/ci/aws-lambda-ruby-dev/3.2/Dockerfile
+++ b/ci/aws-lambda-ruby-dev/3.2/Dockerfile
@@ -5,8 +5,26 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=1
 
 RUN yum install -y amazon-linux-extras yum-utils \
   && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
-  && amazon-linux-extras enable postgresql14 \
-  && yum install -y \
+  && amazon-linux-extras enable postgresql14
+
+# Hopefully a temporary fix until AWS include the mirror for openssl-snapsafe-libs in the base Lambda image
+# Mirror needs be added after command enabling postgresql14, otherwise any pre-existing amzn2-extras.repo is
+# overwritten. See https://github.com/aws/aws-lambda-base-images/issues/245
+RUN <<EOF
+cat >> /etc/yum.repos.d/amzn2-extras.repo << 'EOREPO'
+[amzn2extra-openssl-snapsafe]
+name=Amazon Extras repo for openssl-snapsafe
+enabled=1
+mirrorlist=$awsproto://$amazonlinux.$awsregion.$awsdomain/2/extras/openssl-snapsafe/latest/$basearch/mirror.list
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2
+priority=10
+skip_if_unavailable=1
+report_instanceid=yes
+EOREPO
+EOF
+
+RUN yum install -y \
   postgresql \
   postgresql-devel \
   sqlite-devel \


### PR DESCRIPTION
See https://github.com/aws/aws-lambda-base-images/issues/245 for the full issue details (and basically the solution I used), and FD-2216 ([link](https://uoy.atlassian.net/browse/FD-2216?atlOrigin=eyJpIjoiZGZhMzIzYTE1NmQ0NDFlYzhlOWYzYWIyODNmN2M3NGIiLCJwIjoiaiJ9)).

Unfortunately, I did have to split the `RUN` command up, as it seems that manually creating a `/etc/yum.repos/amzn2-extras.repo` file beforehand will just get overwritten by a subsequent `amazon-linux-extras enable ...` command. Also, there's no subject for `openssl-snapsafe` (`amazon-linux-extras list`), so getting the mirror list added is a manual procedure (done via a HEREDOC in this case).

I've tested building the resulting docker image locally, and it works fine. If you want to give it a go:
```bash
$ cd faculty-dev-docker-images/ci/aws-lambda-ruby-dev/3.2/
$ docker build -t localtesting .    # "localtesting" is entirely arbitrary, tag it with whatever name you want
```